### PR TITLE
Add call to cache flush on disk write

### DIFF
--- a/os/various/fatfs_bindings/fatfs_diskio.c
+++ b/os/various/fatfs_bindings/fatfs_diskio.c
@@ -206,6 +206,9 @@ DRESULT disk_write (
     UINT count        /* Number of sectors to write (1..255) */
 )
 {
+  // invalidate cache on buffer
+  cacheBufferFlush(buff, count * MMCSD_BLOCK_SIZE);
+
   switch (pdrv) {
 #if HAL_USE_MMC_SPI
   case MMC:


### PR DESCRIPTION
- This is required for F7 targets (and others that feature memory cache).
- The call is provided empty for all the other series, so it's OK to use it as it is.